### PR TITLE
Expose the system bus to D-Installer's web UI

### DIFF
--- a/iguana-workflow/examples/d-installer.yaml
+++ b/iguana-workflow/examples/d-installer.yaml
@@ -6,6 +6,7 @@ jobs:
       image: registry.opensuse.org/yast/head/containers/containers_tumbleweed/opensuse/dinstaller-web
       volumes:
         - dbus_run:/var/run/dbus
+        - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     services:
       backend:
         image: registry.opensuse.org/yast/head/containers/containers_tumbleweed/opensuse/dinstaller-backend

--- a/iguana-workflow/examples/d-installer.yaml
+++ b/iguana-workflow/examples/d-installer.yaml
@@ -12,3 +12,4 @@ jobs:
         image: registry.opensuse.org/yast/head/containers/containers_tumbleweed/opensuse/dinstaller-backend
         volumes:
           - dbus_run:/var/run/dbus
+          - /etc/NetworkManager:/etc/NetworkManager

--- a/iguana-workflow/examples/d-installer.yaml
+++ b/iguana-workflow/examples/d-installer.yaml
@@ -5,11 +5,12 @@ jobs:
     container:
       image: registry.opensuse.org/yast/head/containers/containers_tumbleweed/opensuse/dinstaller-web
       volumes:
-        - dbus_run:/var/run/dbus
+        - dbus_run:/run/d-installer
         - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
     services:
       backend:
         image: registry.opensuse.org/yast/head/containers/containers_tumbleweed/opensuse/dinstaller-backend
         volumes:
-          - dbus_run:/var/run/dbus
+          - dbus_run:/run/d-installer
+          - /var/run/dbus/system_bus_socket:/var/run/dbus/system_bus_socket
           - /etc/NetworkManager:/etc/NetworkManager


### PR DESCRIPTION
Once https://github.com/yast/d-installer/pull/384 is merged, D-Installer will use its own D-Bus
server. In addition, it needs to talk to the system D-Bus to interact with NetworkManager. For that
reason, we are exposing the system bus to the web interface.
