### PR TITLE
Include dracut-iguana only on request, add make check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,19 +12,20 @@ kernel_file := $(notdir ${kernel_filepath})
 kernel_version := $(subst ${kernel_prefix}-,,${kernel_filepath})
 
 .PHONY: build
-build: ${build_dir} ${target_dir}/iguana-initrd ${target_dir}/${kernel_file}
+build: ${build_dir} ${build_dir}/iguana-initrd ${build_dir}/${kernel_file}
 	@echo "All done"
 
 ${build_dir}:
 	@mkdir ${build_dir}
 
-${target_dir}/iguana-initrd:
+${build_dir}/iguana-initrd:
 	@echo "Generating initrd"
-	dracut --force --no-hostonly --no-hostonly-cmdline \
-	       --no-hostonly-default-device --no-hostonly-i18n \
-		   --reproducible ${build_dir}/iguana-initrd ${kernel_version}
+	dracut --force --no-hostonly --no-hostonly-cmdline      \
+			--no-hostonly-default-device --no-hostonly-i18n \
+			--no-machineid --reproducible --add iguana      \
+			${build_dir}/iguana-initrd ${kernel_version}
 
-${target_dir}/${kernel_file}:
+${build_dir}/${kernel_file}:
 	@echo "Collecting kernel used for initrd build"
 	@cp ${kernel_filepath} ${build_dir}/${kernel_file}
 
@@ -35,6 +36,9 @@ install:
 	done
 
 all: build install
+
+check:
+	lsinitrd -m ${target_dir}/iguana-initrd | grep -q iguana
 
 clean:
 	rm -r ${build_dir}

--- a/dracut-iguana/iguana/module-setup.sh
+++ b/dracut-iguana/iguana/module-setup.sh
@@ -2,7 +2,10 @@
 
 # called by dracut
 check() {
-    return 0
+    require_binaries iguana-workflow || return 1
+
+    #do not add this module by default
+    return 255
 }
 
 # called by dracut

--- a/iguana.spec
+++ b/iguana.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package iguana
 #
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2023 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -40,6 +40,9 @@ Initrd for container based, expandable installation and recovery.
 
 %install
 %make_install
+
+%check
+make check DESTDIR=%{buildroot}
 
 %files
 %dir %{_datadir}/iguana


### PR DESCRIPTION
* ensure iguana dracut module is always included in iguana package or fail the build
* if dracut-iguana is installed on system, do not include it in initrd automatically, only when explicitly asked to do so
