### PR TITLE
Enable new d-installer

### DIFF
--- a/dracut-iguana/dracut-iguana.changes
+++ b/dracut-iguana/dracut-iguana.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Thu Feb 16 14:56:22 UTC 2023 - Ondrej Holecek <oholecek@suse.com>
+
+- Allow options as 3rd option in mountlist (gh#openSUSE/iguana#21)
+
+-------------------------------------------------------------------
 Fri Jan  6 13:25:44 UTC 2023 - Ondrej Holecek <oholecek@suse.com>
 
 - Add root partition auto-detection and encrypted root detection

--- a/dracut-iguana/dracut-iguana.changes
+++ b/dracut-iguana/dracut-iguana.changes
@@ -2,6 +2,8 @@
 Thu Feb 16 14:56:22 UTC 2023 - Ondrej Holecek <oholecek@suse.com>
 
 - Allow options as 3rd option in mountlist (gh#openSUSE/iguana#21)
+- Switch to use network-manager instead of network-legacy
+  (gh#openSUSE/iguana#15)
 
 -------------------------------------------------------------------
 Fri Jan  6 13:25:44 UTC 2023 - Ondrej Holecek <oholecek@suse.com>

--- a/dracut-iguana/dracut-iguana.spec
+++ b/dracut-iguana/dracut-iguana.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package dracut-iguana
 #
-# Copyright (c) 2022 SUSE LLC
+# Copyright (c) 2023 SUSE LLC
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -25,16 +25,17 @@ Group:          System/Packages
 URL:            https://github.com/openSUSE/iguana
 Source:         %{name}-%{version}.tar
 BuildRequires:  dracut
+Requires:       NetworkManager
 Requires:       curl
+Requires:       dbus-1
 Requires:       dracut
 Requires:       grep
 Requires:       iguana-workflow
 Requires:       iproute2
+Requires:       jq
 Requires:       kexec-tools
 Requires:       podman
 Requires:       procps
-Requires:       wicked
-Requires:       jq
 BuildArch:      noarch
 
 %description

--- a/dracut-iguana/iguana/iguana.sh
+++ b/dracut-iguana/iguana/iguana.sh
@@ -154,7 +154,7 @@ if [ ! -f /iguana/mountlist ]; then
   iguana_reboot_action "reboot"
 fi
 
-while read device mountpoint; do
+while read -r device mountpoint options; do
   if [ "$mountpoint" == "$NEWROOT" ]; then
     root=$device
     if is_root_encrypted "$device"; then
@@ -162,7 +162,8 @@ while read device mountpoint; do
       iguana_reboot_action "reboot"
     fi
   fi
-  mount "$device" "$mountpoint" || Echo "Failed to mount ${device} as ${mountpoint}"
+  mount --options "$options" --source "$device" --target "$mountpoint" || \
+    Echo "Failed to mount ${device} as ${mountpoint} with options {options}"
 done < /iguana/mountlist
 
 # TODO: add proper kernel action parsing

--- a/dracut-iguana/iguana/iguana.sh
+++ b/dracut-iguana/iguana/iguana.sh
@@ -163,7 +163,7 @@ while read -r device mountpoint options; do
     fi
   fi
   mount --options "$options" --source "$device" --target "$mountpoint" || \
-    Echo "Failed to mount ${device} as ${mountpoint} with options {options}"
+    Echo "Failed to mount ${device} as ${mountpoint} with options ${options}"
 done < /iguana/mountlist
 
 # Scan $NEWROOT for installed kernel, initrd and command line

--- a/dracut-iguana/iguana/module-setup.sh
+++ b/dracut-iguana/iguana/module-setup.sh
@@ -10,7 +10,7 @@ check() {
 
 # called by dracut
 depends() {
-    echo network
+    echo network network-manager
     return 0
 }
 

--- a/dracut-iguana/iguana/module-setup.sh
+++ b/dracut-iguana/iguana/module-setup.sh
@@ -50,7 +50,7 @@ install() {
     inst_multiple lsblk jq
 
     # standard iguana
-    inst_simple iguana-workflow
+    inst iguana-workflow
 
     #TODO
     #install SUSE CA as a trust anchor

--- a/iguana-workflow/obs/iguana-workflow.changes
+++ b/iguana-workflow/obs/iguana-workflow.changes
@@ -1,0 +1,4 @@
+-------------------------------------------------------------------
+Fri Feb 17 16:10:02 UTC 2023 - Ondrej Holecek <oholecek@suse.com>
+
+- First release

--- a/iguana-workflow/src/engines/podman.rs
+++ b/iguana-workflow/src/engines/podman.rs
@@ -97,10 +97,13 @@ impl ContainerOps for Podman {
         if container.volumes.is_some() {
             for v in container.volumes.as_ref().unwrap() {
                 let src = v.split(":").take(1).collect::<Vec<_>>()[0];
-                match self.prepare_volume(src, opts) {
-                    Ok(()) => {}
-                    Err(e) => {
-                        return Err(e);
+                if !src.starts_with("/") {
+                    // Volume is named volume, prepare it in advance
+                    match self.prepare_volume(src, opts) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            return Err(e);
+                        }
                     }
                 }
                 volumes.push(format!("--volume={v}"));


### PR DESCRIPTION
Once D-Installer switched it's dbus implementation and reliance on Network Manager, it stopped working on Iguana. Backend container always crashed on startup because of missing NetworkManager dbus services. This PR fixes that by including PR #19 and adding some other fixes

Included are:

- Allow options as 3rd option in mountlist ( Fixes #21 )
- Use network-manager instead of network-legacy ( Fixes #15 )
- Allow volumes to be unnamed ( Partial fix #18 )