### PR TITLE
Allow iguana.control_url to be local file path

### DIFF
--- a/dracut-iguana/dracut-iguana.changes
+++ b/dracut-iguana/dracut-iguana.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Feb 24 14:15:37 UTC 2023 - Ondrej Holecek <oholecek@suse.com>
+
+- Allow to specify local path as control_url pointing to workflow
+  files bundled with iguana initrd (gh#openSUSE/iguana#2)
+
+-------------------------------------------------------------------
 Thu Feb 16 14:56:22 UTC 2023 - Ondrej Holecek <oholecek@suse.com>
 
 - Allow options as 3rd option in mountlist (gh#openSUSE/iguana#21)

--- a/dracut-iguana/iguana/iguana.sh
+++ b/dracut-iguana/iguana/iguana.sh
@@ -115,7 +115,7 @@ if [ -n "$IGUANA_CONTROL_URL" ]; then
   fi
 fi
 
-if [ -f control_url.yaml ]; then
+if [ -f "$IGUANA_URL_WORKFLOW" ]; then
   $IGUANA_WORKFLOW "${IGUANA_CMDLINE_EXTRA[@]}" "$IGUANA_URL_WORKFLOW"
 elif [ -n "$IGUANA_CONTAINERS" ]; then
   Echo "Using container list from kcmdline: ${IGUANA_CONTAINERS}"


### PR DESCRIPTION
Option rd.iguana.control_url can now be local file path. If matching file is located, then it is used as a workflow control file.

This commit also includes some shellcheck suggested fixes.

Fixes #2 