### PR TITLE
Update project repository and links

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,29 +1,29 @@
 pr_workflow:
   steps:
     - branch_package:
-        source_project: home:oholecek:iguana
+        source_project: systemsmanagement:Iguana:Devel
         source_package: dracut-iguana
-        target_project: home:oholecek:iguana:PRs
+        target_project: systemsmanagement:Iguana:Devel
     - branch_package:
-        source_project: home:oholecek:iguana
+        source_project: systemsmanagement:Iguana:Devel
         source_package: iguana-workflow
-        target_project: home:oholecek:iguana:PRs
+        target_project: systemsmanagement:Iguana:Devel
     - branch_package:
-        source_project: home:oholecek:iguana
+        source_project: systemsmanagement:Iguana:Devel
         source_package: iguana
-        target_project: home:oholecek:iguana:PRs
+        target_project: systemsmanagement:Iguana:Devel
   filters:
     event: pull_request
 rebuild_master:
   steps:
     - trigger_services:
-        project: home:oholecek:iguana
+        project: systemsmanagement:Iguana:Devel
         package: dracut-iguana
     - trigger_services:
-        project: home:oholecek:iguana
+        project: systemsmanagement:Iguana:Devel
         package: iguana-workflow
     - trigger_services:
-        project: home:oholecek:iguana
+        project: systemsmanagement:Iguana:Devel
         package: iguana
   filters:
     event: push

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Iguana is split in multiple packages:
 - Iguana orchestrator [iguana-workflow](https://github.com/openSUSE/iguana/tree/main/iguana-workflow)
 - This overall project
 
-Packages are available for openSUSE systems at [OBS](https://build.opensuse.org):
+Devel packages are available at [OBS project](https://build.opensuse.org/project/show/systemsmanagement:Iguana:Devel):
 
-- [dracut-iguana](https://build.opensuse.org/package/show/home:oholecek:iguana/dracut-iguana)
-- [iguana-workflow](https://build.opensuse.org/package/show/home:oholecek:iguana/iguana-workflow)
-- [iguana initrd](https://build.opensuse.org/package/show/home:oholecek:iguana/iguana)
+- [dracut-iguana](https://build.opensuse.org/package/show/systemsmanagement:Iguana:Devel/dracut-iguana)
+- [iguana-workflow](https://build.opensuse.org/package/show/systemsmanagement:Iguana:Devel/iguana-workflow)
+- [iguana initrd](https://build.opensuse.org/package/show/systemsmanagement:Iguana:Devel/iguana)
 
 ## Testing iguana
 
@@ -36,7 +36,7 @@ Iguana understands three kernel command line options which are used for influenc
 - rd.iguana.containers <container_image>, ...
     Use to manually set what container(s) to run. This will make Iguana to pull and start containers.
 - rd.iguana.control_url
-    Use to point Iguana to [iguana workflow file](https://github.com/openSUSE/iguana/blob/main/iguana-workflow/Workflow.md) on some URL. For example running containerized Agama use `rd.iguana.control_url=https://raw.githubusercontent.com/openSUSE/iguana/main/iguana-workflow/examples/agama.yaml`
+    Use to point Iguana to [iguana workflow file](https://github.com/openSUSE/iguana/blob/main/iguana-workflow/Workflow.md). For example running containerized Agama use `rd.iguana.control_url=https://raw.githubusercontent.com/openSUSE/iguana/main/examples/agama.yaml`
 - rd.iguana.debug
     Set to 1 to enable verbose logging
 
@@ -49,10 +49,10 @@ Every container started by iguana is running in **privileged** mode with host ne
 ### Expectations and provides
 
 - Machine ID is provided in `/iguana/machine-id` file.
-- Iguana **expects** `/iguana/mountlist` file after last container is finished. Each line contains device and mountpoint and Iguana will mount all mounts in order specified.
+- Iguana **expects** `/iguana/mountlist` file after last container is finished. Each line contains device, mountpoint and optional mount options. Iguana will mount all mounts in order as they are specified in the mountlist file.
 
 ```
-    device mountpoint
+    device mountpoint mount_options
     device2 mountpoint2
     ...
 ```

--- a/dracut-iguana/README.md
+++ b/dracut-iguana/README.md
@@ -8,35 +8,16 @@ Unstable software, use at your own risk.
 ## How to test
 
 1) have an existing VM. Do not use your own machine!
-2) install `dracut-iguana` package from [OBS](https://build.opensuse.org/package/show/home:oholecek:iguana/dracut-iguana)
+2) install `dracut-iguana` package from [OBS](https://build.opensuse.org/package/show/systemsmanagement:Iguana:Devel/dracut-iguana)
 3) call `dracut --verbose --force --no-hostonly --no-hostonly-cmdline --no-hostonly-default-device --no-hostonly-i18n --reproducible iguana-initrd $kernel_version`
 
   This will generate `iguana-initrd` file in your current directory.
 
 4) Use new VM and boot directly to kernel and `iguana-initrd` created in previous steps.
-5) To test with Agama, use `rd.iguana.control_url=https://raw.githubusercontent.com/openSUSE/iguana/main/iguana-workflow/examples/agama.yaml rd.iguana.debug=1` as kernel command line
+5) To test with Agama, use `rd.iguana.control_url=https://raw.githubusercontent.com/openSUSE/iguana/main/examples/agama.yaml rd.iguana.debug=1` as kernel command line
 
 ### Submit to OBS
 
-[osc](https://openbuildservice.org/help/manuals/obs-user-guide/art.obs.bg.html#sec.obsbg.req) tool is required for submitting to the [OBS project](https://build.opensuse.org/package/show/home:oholecek/iguana-workflow)
+For Devel project OBS workflow automatically trigger package rebuild from git sources after accepting pull request. Per pull requests builds are also available.
 
-1) checkout package to your project space
-
-    `osc bco home:oholecek:iguana dracut-iguana`
-
-2) from withing checked out project update cargo services
-
-    `osc service ra`
-
-2) remove old source tarballs
-3) add new and remove old files
-
-    `osc ar`
-
-4) submit changes to your package
-
-    `osc ci`
-
-5) after tests create submit request
-
-    `osc sr home:oholecek:iguana dracut-iguana`
+Stable release procedure is WIP.

--- a/iguana-workflow/README.md
+++ b/iguana-workflow/README.md
@@ -23,7 +23,7 @@ cargo build --release
 
 ### Submit to OBS
 
-[osc](https://openbuildservice.org/help/manuals/obs-user-guide/art.obs.bg.html#sec.obsbg.req) tool is required for submitting to the [OBS project](https://build.opensuse.org/package/show/home:oholecek:iguana/iguana-workflow)
+[osc](https://openbuildservice.org/help/manuals/obs-user-guide/art.obs.bg.html#sec.obsbg.req) tool is required for submitting to the [OBS project](https://build.opensuse.org/package/show/systemsmanagement:Iguana:Devel/iguana-workflow)
 
 Project is configured to follow [iguana-workflow GitHub repo](https://github.com/openSUSE/iguana). For contributions please create pull requests.
 
@@ -31,7 +31,7 @@ Follow this guide if you want to create your own testing package.
 
 1) checkout package to your project space
 
-    `osc bco home:oholecek iguana-workflow`
+    `osc bco systemsmanagement:Iguana:Devel iguana-workflow`
 
 2) in checked out project, edit `_service` file and change `url` parameter to follow your git repository
 
@@ -49,7 +49,6 @@ Follow this guide if you want to create your own testing package.
     `osc ci`
 
 If you are maintainer updating package in OBS, skip step 2)
-
 
 
 ## Testing


### PR DESCRIPTION
Final place for Iguana will be under systemsmanagement:Iguana project. Since there is no stable release yet, use every where Devel subproject.