### PR TITLE
Enable secondary console when in debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ Iguana understands three kernel command line options which are used for influenc
 - rd.iguana.control_url
     Use to point Iguana to [iguana workflow file](https://github.com/openSUSE/iguana/blob/main/iguana-workflow/Workflow.md). For example running containerized Agama use `rd.iguana.control_url=https://raw.githubusercontent.com/openSUSE/iguana/main/examples/agama.yaml`
 - rd.iguana.debug
-    Set to 1 to enable verbose logging
+    Use to enable debug mode.
+
+For details see [dracut-iguana documentation](https://github.com/openSUSE/iguana/blob/main/dracut-iguana/README.md)
 
 
 ## Writing iguana aware containers

--- a/dracut-iguana/README.md
+++ b/dracut-iguana/README.md
@@ -5,6 +5,27 @@ _part of [Iguana installer research project](https://github.com/openSUSE/iguana)
 
 Unstable software, use at your own risk.
 
+## Configuration options:
+
+Iguana dracut modules is using `rd.iguana` namespace and following options are recognized.
+
+### rd.iguana.control_url
+
+URL or local path to the [Iguana workflow file](https://github.com/openSUSE/iguana/blob/main/iguana-workflow/Workflow.md). Iguana module will try to download file from provided location and then pass it to the iguana-workflow.
+
+### rd.iguana.containers
+
+Provide container image directly instead of using workflow file. Registry must be included in the URL. More containers can be specified, delimited by `,`.
+
+### rd.iguana.debug
+
+Starts iguana debug mode:
+
+* Enables verbose logging for iguana dracut module.
+* Do not remove containers after their run
+* Instead of rebooting on failure drop to the emergency shell
+* Starts debug console on tty2
+
 ## How to test
 
 1) have an existing VM. Do not use your own machine!

--- a/dracut-iguana/iguana/iguana-lib.sh
+++ b/dracut-iguana/iguana/iguana-lib.sh
@@ -8,6 +8,7 @@ if ! declare -f Echo > /dev/null ; then
 fi
 
 if [ -n "$IGUANA_DEBUG" ]; then
+  Echo "Debug mode - starting secondary tty2"
   echo "export PS1='iguana@\h:\w> '" > /root/.bashrc
   setsid -f -- sh -c 'exec /bin/bash </dev/tty2 >/dev/tty2 2>&1'
 fi
@@ -23,7 +24,7 @@ function iguana_reboot_action() {
     sleep 5
   fi
   if [ "unless-debug" == "$2" ] && [ -n "$IGUANA_DEBUG" ]; then
-    Echo "Debug mode enabled, dropping to emergency shell instead of reboot"
+    Echo "Debug mode - dropping to emergency shell instead of reboot"
     emergency_shell -n "iguana"
   else
     reboot -f -d -n

--- a/dracut-iguana/iguana/iguana-lib.sh
+++ b/dracut-iguana/iguana/iguana-lib.sh
@@ -22,7 +22,12 @@ function iguana_reboot_action() {
     Echo "Kexec failed, trying reboot"
     sleep 5
   fi
-  reboot -f -d -n
+  if [ "unless-debug" == "$2" ] && [ -n "$IGUANA_DEBUG" ]; then
+    Echo "Debug mode enabled, dropping to emergency shell instead of reboot"
+    emergency_shell -n "iguana"
+  else
+    reboot -f -d -n
+  fi
 }
 
 function guess_root_mount() {

--- a/dracut-iguana/iguana/iguana-lib.sh
+++ b/dracut-iguana/iguana/iguana-lib.sh
@@ -8,8 +8,8 @@ if ! declare -f Echo > /dev/null ; then
 fi
 
 if [ -n "$IGUANA_DEBUG" ]; then
-  export PS1="iguana@\h:\w> "
-  setsid sh -c 'exec /bin/bash </dev/tty1 >/dev/tty1 2>&1'
+  echo "export PS1='iguana@\h:\w> '" > /root/.bashrc
+  setsid sh -c 'exec /bin/bash </dev/tty2 >/dev/tty2 2>&1'
 fi
 
 function iguana_reboot_action() {

--- a/dracut-iguana/iguana/iguana-lib.sh
+++ b/dracut-iguana/iguana/iguana-lib.sh
@@ -9,7 +9,7 @@ fi
 
 if [ -n "$IGUANA_DEBUG" ]; then
   echo "export PS1='iguana@\h:\w> '" > /root/.bashrc
-  setsid sh -c 'exec /bin/bash </dev/tty2 >/dev/tty2 2>&1'
+  setsid -f -- sh -c 'exec /bin/bash </dev/tty2 >/dev/tty2 2>&1'
 fi
 
 function iguana_reboot_action() {

--- a/dracut-iguana/iguana/iguana-lib.sh
+++ b/dracut-iguana/iguana/iguana-lib.sh
@@ -7,6 +7,11 @@ if ! declare -f Echo > /dev/null ; then
   }
 fi
 
+if [ -n "$IGUANA_DEBUG" ]; then
+  export PS1="iguana@\h:\w> "
+  setsid sh -c 'exec /bin/bash </dev/tty1 >/dev/tty1 2>&1'
+fi
+
 function iguana_reboot_action() {
   # Always do reboot, only in case of kexec action try kexec first
   # Kexec must be already prepared

--- a/dracut-iguana/iguana/iguana.sh
+++ b/dracut-iguana/iguana/iguana.sh
@@ -159,7 +159,7 @@ fi
 if [ ! -f /iguana/mountlist ]; then
   Echo "No partitions to boot from detected! Rebooting in 5 seconds"
   sleep 5
-  iguana_reboot_action "reboot"
+  iguana_reboot_action "reboot" "unless-debug"
 fi
 
 while read -r device mountpoint options; do


### PR DESCRIPTION
This PR enables console on tty when `rd.debug` or `rd.iguana.debug` is present.